### PR TITLE
Add s3 bucket to store domains rather than using aws-frontend-store

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -24,7 +24,6 @@ Parameters:
     Type: String
   DomainsBucket:
     Description: AWS S3 Bucket in which to save skimlinks domains as csv
-    Default: aws-frontend-store
     Type: String
   DomainsKey:
     Description: Key to use in S3 for the file with domains

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -36,6 +36,10 @@ Parameters:
   AlarmEmailRecipient:
     Type: String
     Description: Email address to send alerts to if lambda fails
+  MobileAccountID:
+    Type: String
+    Description: AWS Account ID for mobile team
+
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -144,8 +148,7 @@ Resources:
   SkimlinksDomainsBucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: public-read
-      BucketName: !Ref DomainsBucket # random string on the end for lazy security
+      BucketName: !Ref DomainsBucket
       Tags:
         - Key: App
           Value: skimlinks
@@ -163,5 +166,7 @@ Resources:
           - Action:
               - "s3:GetObject"
             Effect: "Allow"
-            Resource: !Sub arns:aws:s3:::${DomainsBucket}/${DomainsKey}
-            Principal: "201359054765"
+            Resource: !Sub arn:aws:s3:::${DomainsBucket}/${DomainsKey}
+            Principal:
+              AWS:
+                - !Sub arn:aws:iam::${MobileAccountID}:root

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -141,3 +141,28 @@ Resources:
       Statistic: Sum
       Threshold: 1
       Unit: Count
+
+  SkimlinksDomainsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: public-read
+      BucketName: !Ref DomainsBucket # random string on the end for lazy security
+      Tags:
+        - Key: App
+          Value: skimlinks
+        - Key: Stack
+          Value: frontend
+        - Key: Stage
+          Value: PROD
+
+  DomainsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref DomainsBucket
+      PolicyDocument:
+        Statement:
+          - Action:
+              - "s3:GetObject"
+            Effect: "Allow"
+            Resource: !Sub arns:aws:s3:::${DomainsBucket}/${DomainsKey}
+            Principal: "201359054765"


### PR DESCRIPTION
Another aws account needs access to the output of the lambda, so lets store it in a separate S3 bucket with more relaxed security (no encryption)