### PR TITLE
Update the memory size to `512`

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -94,7 +94,7 @@ Resources:
           DomainsKey: !Ref DomainsKey
       Description: A lambda function to periodically update a file in S3 with a list of domains supported by skimlinks.com, fetched from the skimlinks API.
       Handler: com.gu.skimlinkslambda.Lambda::handler
-      MemorySize: 256
+      MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60


### PR DESCRIPTION
After updating to more recent versions of the AWS S3 package, the Lambda would run out of memory while trying to upload the file to S3.

Increasing the memory from 256 to 512 seems to solve this (and the lambda runs significantly faster overall)