### PR TITLE
Use Java 11 runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'adopt'
 
       - name: clean, compile, test, assemble jar, copy to root dir

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,15 @@ scalaVersion := "2.13.12"
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-release:8",
+  "-release:11",
   "-Ywarn-dead-code"
 )
+
+initialize := {
+  val _ = initialize.value
+  assert(sys.props("java.specification.version") == "11",
+    "Java 11 is required for this project.")
+}
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -96,7 +96,7 @@ Resources:
       Handler: com.gu.skimlinkslambda.Lambda::handler
       MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
 
   DailyEvent:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -5,7 +5,6 @@ deployments:
   skimlinks-lambda:
     type: aws-lambda
     parameters:
-      bucket: aws-frontend-artifacts
       functionNames: [skimlinks-lambda-]
       fileName: skimlinks-lambda.jar
       prefixStack: false


### PR DESCRIPTION
Closes https://github.com/guardian/skimlinks-lambda/issues/13

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Upgrades lambda to use Java11 runtime.

AWS is blocking function creation in Java 8 from 8/2/2024: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Compiles successfully. Unfortunately there is no CODE version for this lambda, so I will have to merge and invoke it in PROD. Once merged, will monitor to ensure that the skimlinks bucket continues to be udpated daily.

