### PR TITLE
bumps AWS SDK to `1.12.638`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ src_managed/
 project/boot/
 .history
 .cache
+.vscode/
+.metals/
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "org.slf4j" % "slf4j-simple" % "2.0.5",
   "org.scalaj" %% "scalaj-http" % "2.4.2",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.470"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.638"
 )
 
 val circeVersion = "0.14.6"


### PR DESCRIPTION
## What does this change?

- bumps AWS SDK to `1.12.638`
- ignores files generated by vscode