### PR TITLE
Update the Skimlinks API to v4

### DIFF
--- a/src/main/scala/com/gu/skimlinkslambda/Lambda.scala
+++ b/src/main/scala/com/gu/skimlinkslambda/Lambda.scala
@@ -10,14 +10,32 @@ import org.slf4j.{ Logger, LoggerFactory }
  */
 class LambdaInput() {
   var name: String = _
+
   def getName(): String = name
+
   def setName(theName: String): Unit = name = theName
 }
 
-case class Config(app: String, stack: String, stage: String, skimlinksApiKey: String, skimlinksAccountId: String,
-  bucket: String, domainsKey: String) {
+case class Config(
+  app: String,
+  stack: String,
+  stage: String,
+  skimlinksApiKey: String,
+  skimlinksAccountId: String,
+  skimlinksClientId: String,
+  skimlinksClientSecret: String,
+  bucket: String,
+  domainsKey: String) {
   override def toString: String =
-    s"App: $app, Stack: $stack, Stage: $stage apikey: $skimlinksApiKey accountid: $skimlinksAccountId bucket: $bucket, key: $domainsKey \n"
+    s"App: $app, " +
+      s"Stack: $stack, " +
+      s"Stage: $stage, " +
+      s"apikey: $skimlinksApiKey, " +
+      s"accountId: $skimlinksAccountId, " +
+      s"clientId: $skimlinksClientId, " +
+      s"clientSecret: $skimlinksClientSecret, " +
+      s"bucket: $bucket, " +
+      s"domainsKey: $domainsKey \n"
 }
 
 object Lambda {
@@ -31,10 +49,21 @@ object Lambda {
       stage <- Option(System.getenv("Stage"))
       apiKey <- Option(System.getenv("SkimlinksApiKey"))
       accountId <- Option(System.getenv("SkimlinksAccountId"))
+      clientId <- Option(System.getenv("SkimlinksClientId"))
+      clientSecret <- Option(System.getenv("SkimlinksClientSecret"))
       domainsBucket <- Option(System.getenv("DomainsBucket"))
       domainsKey <- Option(System.getenv("DomainsKey"))
     } yield {
-      Config(app, stack, stage, apiKey, accountId, domainsBucket, domainsKey)
+      Config(
+        app = app,
+        stack = stack,
+        stage = stage,
+        skimlinksApiKey = apiKey,
+        skimlinksAccountId = accountId,
+        skimlinksClientId = clientId,
+        skimlinksClientSecret = clientSecret,
+        bucket = domainsBucket,
+        domainsKey = domainsKey)
     }
   }
 
@@ -53,7 +82,12 @@ object Lambda {
 
   def process(config: Config): Unit = {
     logger.info(s"Fetching the skimlinks domains with config $config")
-    val domains = SkimlinksAPI.getDomains(config.skimlinksApiKey, config.skimlinksAccountId)
+
+    val domains = SkimlinksAPI.getAccessToken(config.skimlinksClientId, config.skimlinksClientSecret) match {
+      case Some(authToken) => SkimlinksAPI.getDomains(authToken, config.skimlinksAccountId)
+      case None => List.empty
+    }
+
     if (domains.isEmpty) {
       logger.error("Failed to fetch domains from skimlinks api")
       System.exit(1)
@@ -68,9 +102,9 @@ object TestIt {
   def main(args: Array[String]): Unit = {
     args.foreach(println)
     if (args.length < 4) {
-      println("Usage: run <apikey> <accountid> <bucket> <key>")
+      println("Usage: run <apikey> <accountId> <clientId> <clientSecret> <domainsBucket> <domainsKey>")
     } else {
-      Lambda.process(Config("test", "test", "test", args(0), args(1), args(2), args(3)))
+      Lambda.process(Config("test", "test", "test", args(0), args(1), args(2), args(3), args(4), args(5)))
     }
   }
 }

--- a/src/main/scala/com/gu/skimlinkslambda/SkimlinksAPI.scala
+++ b/src/main/scala/com/gu/skimlinkslambda/SkimlinksAPI.scala
@@ -1,21 +1,41 @@
 package com.gu.skimlinkslambda
 
-import scalaj.http._
-import io.circe._
 import io.circe.parser._
-import org.slf4j.{ Logger, LoggerFactory }
+import org.slf4j.{Logger, LoggerFactory}
+import scalaj.http._
 
 object SkimlinksAPI {
 
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  def getDomains(apiKey: String, accountId: String): List[String] = {
-    val skimLinksDomainsUrl: String = s"https://merchants.skimapis.com/v3/domains"
+  def getAccessToken(clientId: String, clientSecret: String): Option[String] = {
+    val authResponse = Http(
+      url = "https://authentication.skimapis.com/access_token",
+    ).postData(
+      s"""{
+         | "client_id": "$clientId",
+         | "client_secret": "$clientSecret",
+         | "grant_type": "client_credentials"
+         |}""".stripMargin
+    ).asString
+
+    if (authResponse.isSuccess) {
+      parse(authResponse.body).map { authJson =>
+        authJson.hcursor.
+          downField("access_token").as[String]
+      }.flatMap { result =>
+        result
+      }.toOption
+    } else {
+      None
+    }
+  }
+
+  def getDomains(accessToken: String, publisherId: String): List[String] = {
+    val skimLinksDomainsUrl: String = s"https://merchants.skimapis.com/v4/publisher/$publisherId/domains"
 
     val domainsJson = Http(skimLinksDomainsUrl)
-      .param("apikey", apiKey)
-      .param("account_type", "publisher_admin")
-      .param("account_id", accountId)
+      .param("access_token", accessToken)
       .asString
 
     if (domainsJson.isSuccess) {


### PR DESCRIPTION
## What does this change?

Updates the Skimlinks API to V4 following these docs: 
https://developers.skimlinks.com/

## Why

This lambda stared failing 2 days ago with a 401 Unauthorised response. Since our API key has not changed we're hoping updating the authentication method to the latest recommended version will fix things. 

## How to test 

Run on CODE and see the list of domains being updated in s3 correctly