### PR TITLE
Specify minimum version of jackson-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser"
 ).map(_ % circeVersion)
 
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "[2.16,)"
+
 assembly / assemblyMergeStrategy := {
   case PathList(ps @ _*) if ps.last == "module-info.class" => MergeStrategy.discard
   case x =>


### PR DESCRIPTION
## What does this change?
Specifies a minimum version of `jackson-core` to resolve a security vulnerability.
