### PR TITLE
Start using guardian/setup-scala actions and increase read timeout for getDomains

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,11 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          cache: sbt
-          java-version: 11
+      - uses: guardian/setup-scala@v1
 
       - name: clean, compile, test, assemble jar, copy to root dir
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,9 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          distribution: corretto
+          cache: sbt
+          java-version: 11
 
       - name: clean, compile, test, assemble jar, copy to root dir
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1

--- a/src/main/scala/com/gu/skimlinkslambda/SkimlinksAPI.scala
+++ b/src/main/scala/com/gu/skimlinkslambda/SkimlinksAPI.scala
@@ -37,6 +37,7 @@ object SkimlinksAPI {
 
     val domainsJson = Http(skimLinksDomainsUrl)
       .param("access_token", accessToken)
+      .timeout(connTimeoutMs = 10000, readTimeoutMs = 10000)
       .asString
 
     if (domainsJson.isSuccess) {


### PR DESCRIPTION
## What does this change?
Updates the timeout when requesting domains from skimlinks to be longer than the default. The lambda was failing due to the request taking longer than the timeout.

Also updates the build action to use the `guardian/setup-scala` action. The build action was failing without this as `setup-java` no longer sets up sbt. I've chosen to use the guardian action as it contains best practices for guardian repos. This action requires a Java version to be specified in a `.tool-versions` file, so this PR also adds that. 

