### PR TITLE
Increasing alarm period to a day

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -137,7 +137,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: 60
+      Period: 86400
       Statistic: Sum
       Threshold: 1
       Unit: Count


### PR DESCRIPTION
## What does this change?
Update [CloudWatch alarm ](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/skimlinks-lambda-PROD-ErrorAlarm-ANHGUUQ6667V?~%28search~%27skim%29) for the skimlinks lambda by
- Adjusting ErrorAlarm in cfn.yaml to use a 24-hour period (86400 seconds) instead of 60 seconds.
- Keeping EvaluationPeriods to 1, so errors are checked once per day.

This should ensure the alarm evaluates over the same interval as the Skimlinks Lambda (daily execution) and hopefully prevent the alarm from going into "Insufficient Data" when the Lambda runs once per day.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
