### PR TITLE
Bump riff-raff action to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,15 +19,12 @@ jobs:
           sbt -v clean compile test assembly
           cp target/scala*/skimlinks-lambda.jar .
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Upload to Riff-Raff
-        uses: guardian/actions-riff-raff@v2.2.2
+        uses: guardian/actions-riff-raff@v4
         with:
           projectName: skimlinks-lambda
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           configPath: riff-raff.yaml
           buildNumberOffset: 135
           contentDirectories: |


### PR DESCRIPTION
## What does this change?
I've updated the version of the riff-raff action we use as it was out of date. Using the latest version means we no longer need the configure-aws-credentials step, so I've removed it. See [docs here](https://github.com/guardian/actions-riff-raff?tab=readme-ov-file#migrating-from-v3-to-v4) for more info!

Also just recording here that I've updated the continuous deployment configuration for this repo in the riff-raff UI. The configuration was looking for merges to master instead of main, which is why the deploys haven't been working for a while. This should now be sorted going forward.